### PR TITLE
Fix interest request flow and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ CC=${ARCH}-linux-musl-gcc cargo build --package udcn2 --release \
 The cross-compiled program `target/${ARCH}-unknown-linux-musl/release/udcn2` can be
 copied to a Linux server or VM and run there.
 
+## CLI Usage
+
+`udcn2-cli` provides utilities for sending Interests and running benchmarks.
+When the optional `--xdp` flag is supplied, the tool starts the XDP loader on
+the specified interface before executing the chosen command.
+
+Example:
+
+```shell
+RUST_LOG=info ./target/release/udcn2-cli interest --server 127.0.0.1:4433 \
+    --name /example/data --count 10 --xdp eth0
+```
+
 ## License
 
 With the exception of eBPF code, udcn2 is distributed under the terms

--- a/notes.md
+++ b/notes.md
@@ -120,6 +120,7 @@ Here are the commands to run the μDCN benchmarks and tools:
   - --iface: Network interface (default: eth0)
   - --stats-interval: Statistics reporting interval in seconds (default: 5)
   - --verbose: Enable detailed statistics
+  - --xdp: Start the XDP loader on the specified interface before running commands
 
   7. Expected Output
 

--- a/udcn2-cli/Cargo.toml
+++ b/udcn2-cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 udcn2-common = { path = "../udcn2-common" }
 udcn2-quic = { path = "../udcn2-quic" }
+udcn2 = { path = "../udcn2" }
 
 [[bin]]
 name = "test-server"

--- a/udcn2-cli/src/main.rs
+++ b/udcn2-cli/src/main.rs
@@ -12,6 +12,9 @@ use udcn2_quic::QuicTransport;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+    /// Optional network interface for starting the XDP program
+    #[arg(long)]
+    xdp: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -56,6 +59,16 @@ async fn main() -> Result<()> {
     
     let cli = Cli::parse();
 
+    let xdp_task = if let Some(iface) = cli.xdp.clone() {
+        Some(tokio::spawn(async move {
+            if let Err(e) = udcn2::run_xdp(&iface).await {
+                log::error!("XDP loader failed: {}", e);
+            }
+        }))
+    } else {
+        None
+    };
+
     match &cli.command {
         Commands::Interest { server, name, count, interval } => {
             run_interest_test(*server, name, *count, *interval).await?;
@@ -63,6 +76,10 @@ async fn main() -> Result<()> {
         Commands::Benchmark { server, connections, duration } => {
             run_benchmark(*server, *connections, *duration).await?;
         }
+    }
+
+    if let Some(task) = xdp_task {
+        task.abort();
     }
 
     Ok(())

--- a/udcn2-quic/src/client.rs
+++ b/udcn2-quic/src/client.rs
@@ -133,10 +133,11 @@ impl ServerCertVerifier for SkipServerVerification {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_test;
 
     #[tokio::test]
     async fn test_quic_client_creation() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
         let addr = "127.0.0.1:0".parse().unwrap();
         let client = QuicClient::new(addr).unwrap();
         assert!(client.local_addr().is_ok());
@@ -144,6 +145,8 @@ mod tests {
     
     #[tokio::test]
     async fn test_insecure_client_creation() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
         let addr = "127.0.0.1:0".parse().unwrap();
         let client = QuicClient::insecure(addr).unwrap();
         assert!(client.local_addr().is_ok());

--- a/udcn2-quic/src/lib.rs
+++ b/udcn2-quic/src/lib.rs
@@ -52,15 +52,13 @@ impl QuicTransport {
 
     pub async fn send_interest(&self, interest: Interest, addr: SocketAddr) -> Result<Data> {
         let connection = self.endpoint.connect(addr, "localhost")?.await?;
-        let mut stream = connection.open_uni().await?;
-        
+        let (mut send, mut recv) = connection.open_bi().await?;
+
         let packet = NdnPacket::Interest(interest);
         let data = serde_json::to_vec(&packet)?;
-        stream.write_all(&data).await?;
-        stream.finish()?;
-        
-        // Wait for response on a bi-directional stream
-        let (_send, mut recv) = connection.open_bi().await?;
+        send.write_all(&data).await?;
+        send.finish()?;
+
         let response = recv.read_to_end(usize::MAX).await?;
         let response_packet: NdnPacket = serde_json::from_slice(&response)?;
         
@@ -136,10 +134,11 @@ pub fn generate_dummy_cert() -> Result<(Vec<CertificateDer<'static>>, PrivateKey
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_test;
 
     #[tokio::test]
     async fn test_quic_transport_creation() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
         let addr = "127.0.0.1:0".parse().unwrap();
         let transport = QuicTransport::new(addr).unwrap();
         assert!(transport.endpoint.local_addr().is_ok());

--- a/udcn2-quic/src/server.rs
+++ b/udcn2-quic/src/server.rs
@@ -13,9 +13,8 @@ pub struct QuicServer {
     message_rx: mpsc::UnboundedReceiver<ServerMessage>,
 }
 
-#[derive(Debug)]
 pub enum ServerMessage {
-    Interest(Interest, PacketStream),
+    Interest(Interest, Box<dyn FnOnce(NdnPacket) -> Result<()> + Send>),
     Data(Data, PacketStream),
     ConnectionClosed(SocketAddr),
 }
@@ -79,8 +78,8 @@ impl QuicServer {
                 // Handle server messages
                 msg = self.message_rx.recv() => {
                     match msg {
-                        Some(ServerMessage::Interest(interest, stream)) => {
-                            self.handle_interest(interest, stream).await;
+                        Some(ServerMessage::Interest(interest, responder)) => {
+                            self.handle_interest(interest, responder).await;
                         }
                         Some(ServerMessage::Data(data, stream)) => {
                             self.handle_data(data, stream).await;
@@ -103,10 +102,10 @@ impl QuicServer {
     ) -> Result<()> {
         loop {
             match stream.handle_incoming_stream().await {
-                Ok(Some(packet)) => {
+                Ok(Some((packet, responder))) => {
                     match packet {
                         NdnPacket::Interest(interest) => {
-                            if let Err(e) = tx.send(ServerMessage::Interest(interest, stream.clone())) {
+                            if let Err(e) = tx.send(ServerMessage::Interest(interest, responder)) {
                                 log::error!("Failed to send interest message: {}", e);
                                 break;
                             }
@@ -133,7 +132,11 @@ impl QuicServer {
         Ok(())
     }
     
-    async fn handle_interest(&self, interest: Interest, stream: PacketStream) {
+    async fn handle_interest(
+        &self,
+        interest: Interest,
+        responder: Box<dyn FnOnce(NdnPacket) -> Result<()> + Send>,
+    ) {
         log::info!("Received Interest: {}", interest.name());
         
         // For demo purposes, create a simple Data response
@@ -142,7 +145,7 @@ impl QuicServer {
             format!("Data for {}", interest.name()).into_bytes(),
         );
         
-        if let Err(e) = stream.send_data(data).await {
+        if let Err(e) = responder(NdnPacket::Data(data)) {
             log::error!("Failed to send data response: {}", e);
         }
     }
@@ -163,10 +166,11 @@ impl QuicServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_test;
 
     #[tokio::test]
     async fn test_quic_server_creation() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
         let addr = "127.0.0.1:0".parse().unwrap();
         let server = QuicServer::new(addr).unwrap();
         assert!(server.local_addr().is_ok());

--- a/udcn2-quic/src/transport.rs
+++ b/udcn2-quic/src/transport.rs
@@ -49,7 +49,7 @@ impl PacketStream {
         
         // Send the Interest
         send_stream.write_all(&serialized).await?;
-        send_stream.finish().await?;
+        send_stream.finish()?;
         
         // Wait for the Data response
         let response_data = timeout(
@@ -82,12 +82,14 @@ impl PacketStream {
     }
     
     /// Handle incoming stream and respond (for server/forwarder)
-    pub async fn handle_incoming_stream(&self) -> Result<Option<(NdnPacket, Box<dyn FnOnce(NdnPacket) -> Result<()> + Send>)>> {
+    pub async fn handle_incoming_stream(
+        &self,
+    ) -> Result<Option<(NdnPacket, Box<dyn FnOnce(NdnPacket) -> Result<()> + Send>)>> {
         match self.connection.accept_bi().await {
             Ok((send_stream, mut recv_stream)) => {
                 let data = recv_stream.read_to_end(self.config.max_packet_size).await?;
                 let packet: NdnPacket = serde_json::from_slice(&data)?;
-                
+
                 // Create response closure
                 let responder = Box::new(move |response: NdnPacket| -> Result<()> {
                     tokio::task::block_in_place(move || {
@@ -95,12 +97,12 @@ impl PacketStream {
                             let mut send_stream = send_stream;
                             let response_data = serde_json::to_vec(&response)?;
                             send_stream.write_all(&response_data).await?;
-                            send_stream.finish().await?;
+                            send_stream.finish()?;
                             Ok(())
                         })
                     })
                 });
-                
+
                 Ok(Some((packet, responder)))
             }
             Err(quinn::ConnectionError::ApplicationClosed(_)) => Ok(None),
@@ -164,7 +166,6 @@ impl ConnectionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_test;
 
     #[tokio::test]
     async fn test_transport_config_default() {

--- a/udcn2/Cargo.toml
+++ b/udcn2/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 license.workspace = true
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 udcn2-common = { path = "../udcn2-common", features = ["user"] }
 

--- a/udcn2/src/lib.rs
+++ b/udcn2/src/lib.rs
@@ -1,0 +1,44 @@
+use anyhow::{Context, Result};
+use aya::{programs::{Xdp, XdpFlags}, Ebpf};
+use log::{debug, warn};
+
+/// Load and attach the μDCN XDP program to the given network interface.
+///
+/// The function bumps the `RLIMIT_MEMLOCK`, loads the compiled eBPF
+/// program and attaches it to `iface`. The XDP program will remain
+/// attached until the returned future resolves, which happens when a
+/// Ctrl‑C signal is received.
+pub async fn run_xdp(iface: &str) -> Result<()> {
+    // Bump the memlock rlimit for older kernels.
+    let rlim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if ret != 0 {
+        debug!("remove limit on locked memory failed, ret is: {ret}");
+    }
+
+    // Load the eBPF bytecode.
+    let mut ebpf = Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/udcn2"
+    )))?;
+    if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
+        // This can happen if all log statements are removed from the eBPF program.
+        warn!("failed to initialize eBPF logger: {e}");
+    }
+
+    // Attach the XDP program.
+    let program: &mut Xdp = ebpf.program_mut("udcn2").unwrap().try_into()?;
+    program.load()?;
+    program
+        .attach(iface, XdpFlags::default())
+        .context(
+            "failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE",
+        )?;
+
+    // Wait for Ctrl-C.
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/udcn2/src/main.rs
+++ b/udcn2/src/main.rs
@@ -1,55 +1,15 @@
-use anyhow::Context as _;
-use aya::programs::{Xdp, XdpFlags};
 use clap::Parser;
-#[rustfmt::skip]
-use log::{debug, warn};
-use tokio::signal;
 
 #[derive(Debug, Parser)]
 struct Opt {
+    /// Network interface to attach the XDP program to
     #[clap(short, long, default_value = "eth0")]
     iface: String,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let opt = Opt::parse();
-
     env_logger::init();
-
-    // Bump the memlock rlimit. This is needed for older kernels that don't use the
-    // new memcg based accounting, see https://lwn.net/Articles/837122/
-    let rlim = libc::rlimit {
-        rlim_cur: libc::RLIM_INFINITY,
-        rlim_max: libc::RLIM_INFINITY,
-    };
-    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
-    if ret != 0 {
-        debug!("remove limit on locked memory failed, ret is: {ret}");
-    }
-
-    // This will include your eBPF object file as raw bytes at compile-time and load it at
-    // runtime. This approach is recommended for most real-world use cases. If you would
-    // like to specify the eBPF program at runtime rather than at compile-time, you can
-    // reach for `Bpf::load_file` instead.
-    let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
-        env!("OUT_DIR"),
-        "/udcn2"
-    )))?;
-    if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
-        // This can happen if you remove all log statements from your eBPF program.
-        warn!("failed to initialize eBPF logger: {e}");
-    }
-    let Opt { iface } = opt;
-    let program: &mut Xdp = ebpf.program_mut("udcn2").unwrap().try_into()?;
-    program.load()?;
-    program.attach(&iface, XdpFlags::default())
-        .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
-
-    let ctrl_c = signal::ctrl_c();
-    println!("Waiting for Ctrl-C...");
-    ctrl_c.await?;
-    println!("Exiting...");
-
-    Ok(())
+    let opt = Opt::parse();
+    udcn2::run_xdp(&opt.iface).await
 }


### PR DESCRIPTION
## Summary
- fix Quic server message handling to use response closure
- handle incoming bidirectional streams correctly
- update tests to install crypto provider

## Testing
- `cargo check`
- `cargo test`
- `cargo build --bins`
- ran `udcn2-cli interest` against `test-server`

------
https://chatgpt.com/codex/tasks/task_e_686b16d2fb7083218bbc55c2608aaea0