### PR TITLE
Add XDP loader library and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ CC=${ARCH}-linux-musl-gcc cargo build --package udcn2 --release \
 The cross-compiled program `target/${ARCH}-unknown-linux-musl/release/udcn2` can be
 copied to a Linux server or VM and run there.
 
+## CLI Usage
+
+`udcn2-cli` provides utilities for sending Interests and running benchmarks.
+When the optional `--xdp` flag is supplied, the tool starts the XDP loader on
+the specified interface before executing the chosen command.
+
+Example:
+
+```shell
+RUST_LOG=info ./target/release/udcn2-cli interest --server 127.0.0.1:4433 \
+    --name /example/data --count 10 --xdp eth0
+```
+
 ## License
 
 With the exception of eBPF code, udcn2 is distributed under the terms

--- a/notes.md
+++ b/notes.md
@@ -120,6 +120,7 @@ Here are the commands to run the μDCN benchmarks and tools:
   - --iface: Network interface (default: eth0)
   - --stats-interval: Statistics reporting interval in seconds (default: 5)
   - --verbose: Enable detailed statistics
+  - --xdp: Start the XDP loader on the specified interface before running commands
 
   7. Expected Output
 

--- a/udcn2-cli/Cargo.toml
+++ b/udcn2-cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 udcn2-common = { path = "../udcn2-common" }
 udcn2-quic = { path = "../udcn2-quic" }
+udcn2 = { path = "../udcn2" }
 
 [[bin]]
 name = "test-server"

--- a/udcn2-cli/src/main.rs
+++ b/udcn2-cli/src/main.rs
@@ -12,6 +12,9 @@ use udcn2_quic::QuicTransport;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+    /// Optional network interface for starting the XDP program
+    #[arg(long)]
+    xdp: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -56,6 +59,16 @@ async fn main() -> Result<()> {
     
     let cli = Cli::parse();
 
+    let xdp_task = if let Some(iface) = cli.xdp.clone() {
+        Some(tokio::spawn(async move {
+            if let Err(e) = udcn2::run_xdp(&iface).await {
+                log::error!("XDP loader failed: {}", e);
+            }
+        }))
+    } else {
+        None
+    };
+
     match &cli.command {
         Commands::Interest { server, name, count, interval } => {
             run_interest_test(*server, name, *count, *interval).await?;
@@ -63,6 +76,10 @@ async fn main() -> Result<()> {
         Commands::Benchmark { server, connections, duration } => {
             run_benchmark(*server, *connections, *duration).await?;
         }
+    }
+
+    if let Some(task) = xdp_task {
+        task.abort();
     }
 
     Ok(())

--- a/udcn2/Cargo.toml
+++ b/udcn2/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 license.workspace = true
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 udcn2-common = { path = "../udcn2-common", features = ["user"] }
 

--- a/udcn2/src/lib.rs
+++ b/udcn2/src/lib.rs
@@ -1,0 +1,44 @@
+use anyhow::{Context, Result};
+use aya::{programs::{Xdp, XdpFlags}, Ebpf};
+use log::{debug, warn};
+
+/// Load and attach the μDCN XDP program to the given network interface.
+///
+/// The function bumps the `RLIMIT_MEMLOCK`, loads the compiled eBPF
+/// program and attaches it to `iface`. The XDP program will remain
+/// attached until the returned future resolves, which happens when a
+/// Ctrl‑C signal is received.
+pub async fn run_xdp(iface: &str) -> Result<()> {
+    // Bump the memlock rlimit for older kernels.
+    let rlim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if ret != 0 {
+        debug!("remove limit on locked memory failed, ret is: {ret}");
+    }
+
+    // Load the eBPF bytecode.
+    let mut ebpf = Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/udcn2"
+    )))?;
+    if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
+        // This can happen if all log statements are removed from the eBPF program.
+        warn!("failed to initialize eBPF logger: {e}");
+    }
+
+    // Attach the XDP program.
+    let program: &mut Xdp = ebpf.program_mut("udcn2").unwrap().try_into()?;
+    program.load()?;
+    program
+        .attach(iface, XdpFlags::default())
+        .context(
+            "failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE",
+        )?;
+
+    // Wait for Ctrl-C.
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/udcn2/src/main.rs
+++ b/udcn2/src/main.rs
@@ -1,55 +1,15 @@
-use anyhow::Context as _;
-use aya::programs::{Xdp, XdpFlags};
 use clap::Parser;
-#[rustfmt::skip]
-use log::{debug, warn};
-use tokio::signal;
 
 #[derive(Debug, Parser)]
 struct Opt {
+    /// Network interface to attach the XDP program to
     #[clap(short, long, default_value = "eth0")]
     iface: String,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let opt = Opt::parse();
-
     env_logger::init();
-
-    // Bump the memlock rlimit. This is needed for older kernels that don't use the
-    // new memcg based accounting, see https://lwn.net/Articles/837122/
-    let rlim = libc::rlimit {
-        rlim_cur: libc::RLIM_INFINITY,
-        rlim_max: libc::RLIM_INFINITY,
-    };
-    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
-    if ret != 0 {
-        debug!("remove limit on locked memory failed, ret is: {ret}");
-    }
-
-    // This will include your eBPF object file as raw bytes at compile-time and load it at
-    // runtime. This approach is recommended for most real-world use cases. If you would
-    // like to specify the eBPF program at runtime rather than at compile-time, you can
-    // reach for `Bpf::load_file` instead.
-    let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
-        env!("OUT_DIR"),
-        "/udcn2"
-    )))?;
-    if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
-        // This can happen if you remove all log statements from your eBPF program.
-        warn!("failed to initialize eBPF logger: {e}");
-    }
-    let Opt { iface } = opt;
-    let program: &mut Xdp = ebpf.program_mut("udcn2").unwrap().try_into()?;
-    program.load()?;
-    program.attach(&iface, XdpFlags::default())
-        .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
-
-    let ctrl_c = signal::ctrl_c();
-    println!("Waiting for Ctrl-C...");
-    ctrl_c.await?;
-    println!("Exiting...");
-
-    Ok(())
+    let opt = Opt::parse();
+    udcn2::run_xdp(&opt.iface).await
 }


### PR DESCRIPTION
## Summary
- expose `run_xdp()` from `udcn2` crate
- call it from new `udcn2` library main binary
- allow `udcn2-cli` to optionally launch the XDP loader via `--xdp`
- document the new flag in README and notes

## Testing
- `cargo check` *(fails: CannotFindBinaryPath from udcn2-ebpf build script)*

------
https://chatgpt.com/codex/tasks/task_e_686b1d2f28a48321b37c831e1e85e9cf